### PR TITLE
Ci cd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,25 @@
 # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
 # https://www.baeldung.com/ops/github-actions-commit-sha
 # https://docs.docker.com/build/ci/github-actions/manage-tags-labels/
+# https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow
 
 name: Build Container
 
 on:
   workflow_call:
+    inputs:
+      DOCKERHUB_USERNAME:
+        required: true
+        type: string
+      DOCKERHUB_REPO:
+        required: true
+        type: string
+      DOCKERHUB_IMAGE:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_TOKEN:
+        required: true
   workflow_dispatch:
 
 jobs:
@@ -22,14 +36,14 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME || inputs.DOCKERHUB_USERNAME}}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags & label) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMAGE }}
+          images: ${{ vars.DOCKERHUB_REPO || inputs.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMAGE || inputs.DOCKERHUB_IMAGE }}
           tags: |
             type=sha,format=short
             type=raw,value=latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,6 @@ name: Build Container
 
 on:
   workflow_call:
-    inputs:
-      DOCKERHUB_USERNAME:
-        required: true
-        type: string
-      DOCKERHUB_REPO:
-        required: true
-        type: string
-      DOCKERHUB_IMAGE:
-        required: true
-        type: string
     secrets:
       DOCKERHUB_TOKEN:
         required: true
@@ -36,14 +26,14 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME || inputs.DOCKERHUB_USERNAME}}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags & label) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKERHUB_REPO || inputs.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMAGE || inputs.DOCKERHUB_IMAGE }}
+          images: ${{ vars.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMAGE }}
           tags: |
             type=sha,format=short
             type=raw,value=latest

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -1,20 +1,20 @@
+
 name: CI Operator
 
 on:
+  workflow_dispatch:
 #  pull_request:
 #    branches:
 #      - master
 #  push:
 #    branches:
 #      - master
-  workflow_dispatch:
 
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
   test:
-    environment: CI
     uses: ./.github/workflows/test.yml
     with:
       DEBUG: ${{ vars.DEBUG }}
@@ -25,7 +25,6 @@ jobs:
 
   build:
     needs: [ lint, test]
-    environment: CI
     uses: ./.github/workflows/build.yml
     with:
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -3,12 +3,12 @@ name: CI Operator
 
 on:
   workflow_dispatch:
-#  pull_request:
-#    branches:
-#      - master
-#  push:
-#    branches:
-#      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   lint:

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -14,8 +14,22 @@ jobs:
     uses: ./.github/workflows/lint.yml
 
   test:
+    environment: CI
     uses: ./.github/workflows/test.yml
+    with:
+      DEBUG: ${{ vars.DEBUG }}
+      DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
+    secrets:
+      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+
 
   build:
-    needs: [lint, test]
+    needs: [ lint, test]
+    environment: CI
     uses: ./.github/workflows/build.yml
+    with:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_REPO: ${{ vars.DOCKERHUB_REPO }}
+      DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -16,9 +16,6 @@ jobs:
 
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      DEBUG: ${{ vars.DEBUG }}
-      DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
     secrets:
       DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
 
@@ -26,9 +23,5 @@ jobs:
   build:
     needs: [ lint, test]
     uses: ./.github/workflows/build.yml
-    with:
-      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
-      DOCKERHUB_REPO: ${{ vars.DOCKERHUB_REPO }}
-      DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
     secrets:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,19 @@
 # https://realpython.com/github-actions-python/
+# https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow
 name: Tests
 
 on:
   workflow_call:
+    inputs:
+      DEBUG:
+        required: true
+        type: string
+      DJANGO_ALLOWED_HOSTS:
+        required: true
+        type: string
+    secrets:
+      DJANGO_SECRET_KEY:
+        required: true
   workflow_dispatch:
 
 jobs:
@@ -11,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DEBUG: ${{ vars.DEBUG }}
-      DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
+      DEBUG: ${{ vars.DEBUG || inputs.DEBUG }}
+      DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS || inputs.DJANGO_ALLOWED_HOSTS }}
       DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,6 @@ name: Tests
 
 on:
   workflow_call:
-    inputs:
-      DEBUG:
-        required: true
-        type: string
-      DJANGO_ALLOWED_HOSTS:
-        required: true
-        type: string
     secrets:
       DJANGO_SECRET_KEY:
         required: true
@@ -22,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DEBUG: ${{ vars.DEBUG || inputs.DEBUG }}
-      DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS || inputs.DJANGO_ALLOWED_HOSTS }}
+      DEBUG: ${{ vars.DEBUG }}
+      DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
       DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
 
     steps:


### PR DESCRIPTION
# Notes

- CI pipeline finished.
- CI pipeline trigger on PR/push on master.

## Informations
- A ci-operators orchestrate the CI actions (lint, test, build). 
- The action can be triggered manually independently.
- When workflow call is used, secrets need to be passed by the orchestrator.
source: [github action doc](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow
). 
Not sure why the secrets need to be given since the jobs still access the CI environment but here is an example where the workflow would not be able to access a secret : [failed workflow without the secrets given explicitely](https://github.com/a-beduc/formation_project_13/actions/runs/16723255390)